### PR TITLE
cleanup dockerfile, reduce deps, disable hipe/odbc

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,9 +4,11 @@
 .gitignore
 .sonarlint
 .vscode
+CONTRIBUTORS.md
 dive.log
 Dockerfile
 LICENSE
 Makefile
 README.md
+slim.report.json
 VERSION

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .sonarlint
 .vscode
 dive.log
+slim.report.json

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+# Contributors
+
+- Mårten Wikström (@mwik)

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,16 @@ LABEL maintainer="beardedeagle <randy@heroictek.com>"
 # Important!  Update this no-op ENV variable when this Dockerfile
 # is updated with the current date. It will force refresh of all
 # of the base images.
-ENV REFRESHED_AT=2020-10-22 \
+ENV REFRESHED_AT=2020-10-23 \
   OTP_VER=23.1.1 \
   REBAR3_VER=3.14.1 \
   TERM=xterm \
   LANG=C.UTF-8
 
 RUN set -xe \
-  && apk --update --no-cache upgrade \
-  && apk add --no-cache \
-    bash \
-    openssl \
-    lksctp-tools \
+  && apk --no-cache update \
+  && apk --no-cache upgrade \
+  && apk add --no-cache bash openssl \
   && rm -rf /root/.cache \
   && rm -rf /var/cache/apk/*
 
@@ -25,25 +23,24 @@ FROM base_stage as deps_stage
 RUN set -xe \
   && apk add --no-cache --virtual .build-deps \
     autoconf \
-    bash-dev \
-    binutils-gold \
-    ca-certificates \
-    curl curl-dev \
-    dpkg dpkg-dev \
+    curl \
+    dpkg \
+    dpkg-dev \
     g++ \
     gcc \
-    libc-dev \
-    openssl-dev \
-    linux-headers \
-    lksctp-tools-dev \
     make \
-    musl musl-dev \
-    ncurses ncurses-dev \
+    musl \
+    musl-dev \
+    ncurses \
+    ncurses-dev \
+    openssl \
+    openssl-dev \
     rsync \
+    sed \
     tar \
-    unixodbc unixodbc-dev \
-    zlib zlib-dev \
-  && update-ca-certificates --fresh
+    unzip \
+    zlib \
+    zlib-dev
 
 FROM deps_stage as erlang_stage
 
@@ -79,11 +76,13 @@ RUN set -xe \
       --without-orber \
       --without-percept \
       --without-typer \
+      --without-odbc \
+      --disable-hipe \
+      --enable-m64-build \
       --enable-threads \
       --enable-shared-zlib \
       --enable-ssl=dynamic-ssl-lib \
       --enable-kernel-poll \
-      --enable-hipe \
     && make -j$(getconf _NPROCESSORS_ONLN) \
     && make install ) \
   && rm -rf $ERL_TOP \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test iex shell build clean rebuild release
+.PHONY: help test erl shell build clean rebuild release
 .NOTPARALLEL: rebuild release
 
 VERSION ?= `cat VERSION`
@@ -10,30 +10,30 @@ help:
 	@echo "$(IMAGE_NAME):$(VERSION)"
 	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-## Test the Docker image
+## Test Docker image
 test:
 	docker run --rm -it $(IMAGE_NAME):$(VERSION) erl -version
 
-## Run an erl shell in the image
+## Run erl shell in Docker image
 erl:
 	docker run --rm -it $(IMAGE_NAME):$(VERSION) erl
 
-## Boot to a shell prompt
+## Boot to shell prompt in Docker image
 shell:
 	docker run --rm -it $(IMAGE_NAME):$(VERSION) /bin/bash
 
-## Build the Docker image
+## Build Docker images
 build:
 	docker build --force-rm -t $(IMAGE_NAME):$(VERSION) -t $(IMAGE_NAME):$(MIN_VERSION) -t $(IMAGE_NAME):latest .
 
-## Clean up generated images
+## Clean up generated Docker images
 clean:
 	@docker rmi --force $(IMAGE_NAME):$(VERSION) $(IMAGE_NAME):$(MIN_VERSION) $(IMAGE_NAME):latest
 
-## Rebuild the Docker image
+## Rebuild Docker images
 rebuild: clean build
 
-## Rebuild and release the Docker image to Docker Hub
+## Build and release Docker images to Docker Hub
 release: build
 	docker push $(IMAGE_NAME):$(VERSION)
 	docker push $(IMAGE_NAME):$(MIN_VERSION)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ To boot straight to a erl prompt in the image:
 
 ```shell
 $ docker run --rm -i -t beardedeagle/alpine-erlang-builder erl
-Erlang/OTP 23 [erts-11.0.2] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1]
+Erlang/OTP 23 [erts-11.1.1] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1]
 
-Eshell V11.0.2  (abort with ^G)
+Eshell V11.1.1  (abort with ^G)
 1>
 ```


### PR DESCRIPTION
- Bumped alpine to 3.12.1
- Bumped otp to 23.1.1
- Bumped rebar 3 to 3.14.1
- Cleaned up Dockerfile, more cleanup to come
- Reduced installed packages, improving overall image size and build time
- Disabled hipe and odbc (if these need to be re-enabled please reach out to me)